### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/server/routes/mpesaRoutes.js
+++ b/server/routes/mpesaRoutes.js
@@ -245,7 +245,8 @@ router.post('/payment', async (req, res) => {
         console.log(`Processing M-Pesa payment: ${amount} KES from ${phoneNumber} for order ${orderId || 'N/A'}`);
         
         // Get the M-Pesa token
-        const tokenResponse = await axios.get(`${req.protocol}://${req.get('host')}/api/mpesa/token`);
+        const tokenBaseUrl = process.env.MPESA_TOKEN_BASE_URL || 'https://default-trusted-url.com';
+        const tokenResponse = await axios.get(`${tokenBaseUrl}/api/mpesa/token`);
         const token = tokenResponse.data.token;
         
         // Prepare STK Push parameters


### PR DESCRIPTION
Potential fix for [https://github.com/Austinkuria/clinique-beauty/security/code-scanning/2](https://github.com/Austinkuria/clinique-beauty/security/code-scanning/2)

To fix the SSRF vulnerability, we should avoid directly using the untrusted `req.get('host')` value in constructing the URL. Instead, we can use a predefined, trusted base URL for the M-Pesa token endpoint. This ensures that the outgoing request always targets a known and safe endpoint, regardless of the `Host` header in the incoming request.

Steps to implement the fix:
1. Define a trusted base URL for the M-Pesa token endpoint in the environment configuration (e.g., `MPESA_TOKEN_BASE_URL`).
2. Replace the dynamic URL construction on line 248 with the trusted base URL.
3. Ensure that the trusted base URL is used consistently throughout the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
